### PR TITLE
SignalR Improvements

### DIFF
--- a/src/Karata.Cli/Program.cs
+++ b/src/Karata.Cli/Program.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using Karata.Cards;
 using Karata.Cards.Extensions;
 using static System.Console;
+using static Karata.Cards.Card.CardFace;
+using static Karata.Cards.Card.CardSuit;
 
 DisplayDeck(deck: Deck.StandardDeck);
 
@@ -23,6 +25,8 @@ AddToDictionary(dictionary, "key1", "value1");
 AddToDictionary(dictionary, "key2", "value2");
 WriteLine(dictionary.Count);
 
+WriteLine(nameof(I.Action));
+
 static void DisplayDeck(Deck deck)
 {
     var title = $"| {"Card",-20}| {"Rank",-5}|";
@@ -35,4 +39,9 @@ static void AddToDictionary(ConcurrentDictionary<string, string> dict, string ke
 {
     if (dict.TryAdd(key, value)) WriteLine($"Added {key} to dictionary.");
     else WriteLine($"Failed to add {key} to dictionary.");
+}
+
+interface I
+{
+    public void Action(string parameter);
 }

--- a/src/Karata.Web/Extensions/HubExtensions.cs
+++ b/src/Karata.Web/Extensions/HubExtensions.cs
@@ -7,9 +7,6 @@ public static class HubExtensions
 {
     /** 
      *  TODO: Timeouts and error handling.
-     *
-     *  REF: https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-wrap-eap-patterns-in-a-task
-     *  REF: https://devblogs.microsoft.com/premier-developer/the-danger-of-the-taskcompletionsourcet-class
      *  REF: https://github.com/SignalR/SignalR/issues/1149#issuecomment-302611992
      */
     public static async Task<T> PromptCallerAsync<T>(
@@ -22,36 +19,11 @@ public static class HubExtensions
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         _ = lookup.TryAdd(key, tcs);
 
-        // Using SendCoreAsync() instead of SendAsync() to avoid splitting array of params.
-        // I'm justified in using SendCoreAsync() because it's the only way to pass an array of params.
-        // REF: https://github.com/aspnet/SignalR/issues/1268
-        // REF: https://stackoverflow.com/questions/57979000/microsoft-aspnetcore-signalr-sendasync-args
-        // REF: https://stackoverflow.com/questions/51590347/difference-between-sendasync-and-sendcoreasync-methods-in-signalr-core/51590442
-        // REF: https://github.com/aspnet/SignalR/issues/2239#issuecomment-387854470
-        // REF: https://github.com/dotnet/aspnetcore/blob/a450cb69b5e4549f5515cdb057a68771f56cefd7/src/SignalR/server/Core/src/ClientProxyExtensions.cs
         await (args.Length switch 
         {
             0 => hub.Clients.Caller.SendAsync(method),
             _ => hub.Clients.Caller.SendCoreAsync(method, args)
         });
-
-        // The alternative is to split the params array and use SendAsync() instead of SendCoreAsync().
-        // A maximum of 10 parameters can be passed to SendAsync().
-        // await (args.Length switch
-        // {
-        //     0 => hub.Clients.Caller.SendAsync(method),
-        //     1 => hub.Clients.Caller.SendAsync(method, args[0]),
-        //     2 => hub.Clients.Caller.SendAsync(method, args[0], args[1]),
-        //     3 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2]),
-        //     4 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3]),
-        //     5 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4]),
-        //     6 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4], args[5]),
-        //     7 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4], args[5], args[6]),
-        //     8 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]),
-        //     9 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]),
-        //     10 => hub.Clients.Caller.SendAsync(method, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]),
-        //     _ => throw new NotSupportedException($"{args.Length} parameters are not supported.")
-        // });
 
         try
         {
@@ -72,12 +44,10 @@ public static class HubExtensions
     ) {
         if (lookup.TryGetValue(key, out var tcs))
         {
-            // Trigger the task continuation
             _ = tcs.TrySetResult(value);
         }
         else
         {
-            // Client response for something that isn't being tracked, might be an error
             var message = new SystemMessage
             {
                 Text = "You did something unexpected.",

--- a/src/Karata.Web/Extensions/HubExtensions.cs
+++ b/src/Karata.Web/Extensions/HubExtensions.cs
@@ -7,6 +7,7 @@ public static class HubExtensions
 {
     /** 
      *  TODO: Timeouts and error handling.
+     *  TODO: .NET 7 - This will be obsolete in .NET 7. 
      *  REF: https://github.com/SignalR/SignalR/issues/1149#issuecomment-302611992
      */
     public static async Task<T> PromptCallerAsync<T>(

--- a/src/Karata.Web/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Web/Hubs/Clients/IGameClient.cs
@@ -11,7 +11,7 @@ public interface IGameClient
     Task AddCardRangeToPile(List<Card> cards);
     Task AddHandToRoom(UIHand hand);
     Task AddToRoom(UIRoom room);
-    Task EndGame(UIUser? winner);
+    Task EndGame(string reason, UIUser? winner);
     Task NotifyTurnProcessed();
     Task PromptCardRequest(bool specific);
     Task PromptLastCardRequest();

--- a/src/Karata.Web/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Web/Hubs/Clients/IGameClient.cs
@@ -6,9 +6,7 @@ namespace Karata.Web.Hubs.Clients;
 
 public interface IGameClient
 {
-    Task AddCardsToDeck(int num);
     Task AddCardsToPlayerHand(UIHand hand, int num);
-    Task AddCardToPile(Card card);
     Task AddCardRangeToHand(List<Card> cards); 
     Task AddCardRangeToPile(List<Card> cards);
     Task AddHandToRoom(UIHand hand);

--- a/src/Karata.Web/Pages/Play.razor
+++ b/src/Karata.Web/Pages/Play.razor
@@ -163,7 +163,7 @@ else
         hubConnection.On<UIUser>("EndGame", winner =>
         {
             Snackbar.Add($"Game over! {(winner?.Email ?? "Nobody")} won this game.", Severity.Info);
-            room = null;
+            LeaveRoom(isEnding: true);
             StateHasChanged();
         });
 
@@ -284,7 +284,7 @@ else
     async Task JoinRoom((string InviteLink, string Password) room) =>
     await hubConnection.SendAsync("JoinRoom", room.InviteLink, room.Password);
 
-    async Task LeaveRoom() => await hubConnection.SendAsync("LeaveRoom", room.InviteLink);
+    async Task LeaveRoom(bool isEnding = false) => await hubConnection.SendAsync("LeaveRoom", room.InviteLink, isEnding);
 
     async Task StartGame() => await hubConnection.SendAsync("StartGame", room.InviteLink);
 

--- a/src/Karata.Web/Pages/Play.razor
+++ b/src/Karata.Web/Pages/Play.razor
@@ -65,7 +65,7 @@ else
                 }
 
                 <MudTooltip Text="Leave Room">
-                    <MudIconButton Icon="@Icons.Rounded.PersonRemove" Color="Color.Inherit" OnClick="LeaveRoom" />
+                    <MudIconButton Icon="@Icons.Rounded.PersonRemove" Color="Color.Inherit" OnClick="() => LeaveRoom()" />
                 </MudTooltip>
                 <MudTooltip Text="Game Details">
                     <MudIconButton Icon="@Icons.Rounded.Info" Color="Color.Inherit" OnClick="() => open = true" />

--- a/src/Karata.Web/Pages/Play.razor
+++ b/src/Karata.Web/Pages/Play.razor
@@ -13,34 +13,34 @@
 @inject IConfiguration Config
 @inject ISnackbar Snackbar
 
-@if (hubConnection.State != HubConnectionState.Connected)
+@if (_hubConnection.State != HubConnectionState.Connected)
 {
     <MudText Typo="Typo.h5" Class="pa-4 my-4">You are not connected to a server.</MudText>
     <MudText Typo="Typo.h6" Class="pa-4 mb-4">If this message persists, reload this page to establish a connection.</MudText>
 }
-else if (room is null)
+else if (_room is null)
 {
     <JoinUI OnJoin="JoinRoom" OnCreate="CreateRoom" />
 }
 else
 {
     <MudDrawerContainer Class="mud-height-full">
-        <MudDrawer @bind-Open="open" Height="100%" Elevation="1" Variant="@DrawerVariant.Temporary" Anchor="Anchor.Bottom" Class="grey lighten-4">
+        <MudDrawer @bind-Open="_open" Height="100%" Elevation="1" Variant="@DrawerVariant.Temporary" Anchor="Anchor.Bottom" Class="grey lighten-4">
             <MudDrawerHeader Class="d-flex justify-space-between align-center pa-2">
                 <MudText Typo="Typo.h6" Class="px-4">Game Info</MudText>
-                <MudIconButton Icon="@Icons.Rounded.Close" Color="Color.Inherit" OnClick="() => open = false" />
+                <MudIconButton Icon="@Icons.Rounded.Close" Color="Color.Inherit" OnClick="() => _open = false" />
             </MudDrawerHeader>
             <MudContainer MaxWidth="MaxWidth.Medium">
                 <MudPaper Class="pa-4 mb-4" Elevation="0">
                     <div class="mb-2">
-                        <MudSwitch @bind-Checked="useCardTable" Color="Color.Primary" Label="Use CardTable UI (Experimental)" />
+                        <MudSwitch @bind-Checked="_useCardTable" Color="Color.Primary" Label="Use CardTable UI (Experimental)" />
                     </div>
                     <MudText Typo="Typo.caption" Class="text-grey">
                         The CardTable UI is still under development and, as such, may contain bugs. Use GameUI for best experience.
                     </MudText>
                 </MudPaper>
                 
-                <DetailsUI Room="room" Player="Player" OnSend="Send" />
+                <DetailsUI Room="_room" Player="Player" OnSend="Send" />
             </MudContainer>
         </MudDrawer>
         <MudPaper Elevation="0" Class="my-4">
@@ -51,7 +51,7 @@ else
                         <MudIconButton Icon="@Icons.Rounded.ArrowCircleUp" Color="Color.Inherit" OnClick="() => PerformTurn(new())" />
                     </MudTooltip>
                     <MudTooltip Text="Play card(s)">
-                        <MudIconButton Icon="@Icons.Rounded.ArrowCircleDown" Color="Color.Inherit" OnClick="() => PerformTurn(currentTurn)" />
+                        <MudIconButton Icon="@Icons.Rounded.ArrowCircleDown" Color="Color.Inherit" OnClick="() => PerformTurn(_currentTurn)" />
                     </MudTooltip>
                 }
 
@@ -68,19 +68,19 @@ else
                     <MudIconButton Icon="@Icons.Rounded.PersonRemove" Color="Color.Inherit" OnClick="() => LeaveRoom()" />
                 </MudTooltip>
                 <MudTooltip Text="Game Details">
-                    <MudIconButton Icon="@Icons.Rounded.Info" Color="Color.Inherit" OnClick="() => open = true" />
+                    <MudIconButton Icon="@Icons.Rounded.Info" Color="Color.Inherit" OnClick="() => _open = true" />
                 </MudTooltip>
             </MudToolBar>
         </MudPaper>
         @if (@Game.IsStarted)
         {
-            if (useCardTable)
+            if (_useCardTable)
             {
-                <CardTable Game="Game" Hand="Hand" Turn="currentTurn" OnAddCardToTurn="AddCardToTurn" OnRemoveCardFromTurn="RemoveCardFromTurn" />
+                <CardTable Game="Game" Hand="Hand" Turn="_currentTurn" OnAddCardToTurn="AddCardToTurn" OnRemoveCardFromTurn="RemoveCardFromTurn" />
             }
             else
             {
-                <GameUI Game="Game" Hand="Hand" Turn="currentTurn" OnAddCardToTurn="AddCardToTurn" OnRemoveCardFromTurn="RemoveCardFromTurn" />
+                <GameUI Game="Game" Hand="Hand" Turn="_currentTurn" OnAddCardToTurn="AddCardToTurn" OnRemoveCardFromTurn="RemoveCardFromTurn" />
             }
         }
         else
@@ -95,21 +95,21 @@ else
     public CookieService CookieService { get; set; }
     [Inject] 
     private IDialogService DialogService { get; set; }
-    private HubConnection hubConnection;
-    private string username;
-    private UIRoom room = null;
-    private UIGame Game => room.Game;
-    private UIHand Hand => Game.Hands.Single(h => h.User.Email == username);
+    private HubConnection _hubConnection;
+    private string _username;
+    private UIRoom _room;
+    private UIGame Game => _room.Game;
+    private UIHand Hand => Game.Hands.Single(h => h.User!.Email == _username);
     private UIUser Player => Hand.User;
-    private List<Card> currentTurn = new();
-    private bool useCardTable = false;
-    bool open = false;
+    private readonly List<Card> _currentTurn = new();
+    private bool _useCardTable;
+    bool _open;
 
     protected override async Task OnInitializedAsync()
     {
         // Get username from AuthenticationStateProvider
         var authState = await Authenticator.GetAuthenticationStateAsync();
-        username = authState.User.Identity.Name;
+        _username = authState.User.Identity!.Name;
 
         // Set up SignalR with Cookie auth
         var container = new CookieContainer();
@@ -117,10 +117,10 @@ else
         {
             Name = ".AspNetCore.Identity.Application",
             Domain = Config["CookieDomain"],
-            Value = CookieService.Cookie
+            Value = CookieService.Cookie!
         });
 
-        hubConnection = new HubConnectionBuilder()
+        _hubConnection = new HubConnectionBuilder()
         .WithUrl(Navigator.ToAbsoluteUri("/game"), opts => opts.Cookies = container)
         .AddJsonProtocol(opts =>
         {
@@ -128,77 +128,83 @@ else
         })
         .Build();
 
-        hubConnection.On<UIHand, int>("AddCardsToPlayerHand", (hand, num) =>
+        _hubConnection.On<UIHand, int>("AddCardsToPlayerHand", (hand, num) =>
         {
-            var playerHand = Game.Hands.Single(h => h.User.Email == hand.User.Email);
-            for (int i = 0; i < num; i++) playerHand.Cards.Add(new());
+            var playerHand = Game.Hands.Single(h => h.User!.Email == hand.User!.Email);
+            for (var i = 0; i < num; i++) playerHand.Cards.Add(new Card());
             StateHasChanged();
         });
 
-        hubConnection.On<List<Card>>("AddCardRangeToHand", cards =>
+        _hubConnection.On<List<Card>>("AddCardRangeToHand", cards =>
         {
             Hand.Cards.AddRange(cards);
             StateHasChanged();
         });
 
-        hubConnection.On<List<Card>>("AddCardRangeToPile", cards =>
+        _hubConnection.On<List<Card>>("AddCardRangeToPile", cards =>
         {
             foreach (var card in cards) Game.Pile.Push(card);
             StateHasChanged();
         });
 
-        hubConnection.On<UIHand>("AddHandToRoom", hand =>
+        _hubConnection.On<UIHand>("AddHandToRoom", hand =>
         {
             Game.Hands.Add(hand);
-            Snackbar.Add($"{hand.User.Email} has joined the room", Severity.Info);
+            Snackbar.Add($"{hand.User!.Email} has joined the room", Severity.Info);
             StateHasChanged();
         });
 
-        hubConnection.On<UIRoom>("AddToRoom", room =>
+        _hubConnection.On<UIRoom>("AddToRoom", room =>
         {
-            this.room = room;
+            _room = room;
             StateHasChanged();
         });
 
-        hubConnection.On<UIUser>("EndGame", winner =>
+        _hubConnection.On<string, UIUser>("EndGame", async (reason, winner) =>
         {
-            Snackbar.Add($"Game over! {(winner?.Email ?? "Nobody")} won this game.", Severity.Info);
-            LeaveRoom(isEnding: true);
+            Snackbar.Add($"Game over! {reason}", Severity.Info);
+            
+            if (winner is not null && winner.Email == _username)
+            {
+                // TODO: Do something special for the winner (e.g. show a victory screen or confetti)
+                Snackbar.Add("You won!");
+            }
+
+            await  LeaveRoom(isEnding: true);
             StateHasChanged();
         });
 
-        hubConnection.On("NotifyTurnProcessed", () =>
+        _hubConnection.On("NotifyTurnProcessed", () =>
         {
-            currentTurn.Clear();
+            _currentTurn.Clear();
             StateHasChanged();
         });
 
-        hubConnection.On<bool>("PromptCardRequest", async specific =>
+        _hubConnection.On<bool>("PromptCardRequest", async specific =>
         {
-            var parameters = new DialogParameters();
-            parameters.Add(nameof(CardRequestModal.Specific), specific);
+            var parameters = new DialogParameters {{nameof(CardRequestModal.Specific), specific}};
             var dialog = DialogService.Show<CardRequestModal>("Request a card", parameters);
             var result = await dialog.Result;
             var data = result.Cancelled ? null : (Card)result.Data;
-            await hubConnection.SendAsync("RequestCard", data);
+            await _hubConnection.SendAsync("RequestCard", data);
         });
 
-        hubConnection.On("PromptLastCardRequest", async () =>
+        _hubConnection.On("PromptLastCardRequest", async () =>
         {
             var dialog = DialogService.ShowMessageBox("Last Card?", "Are you on your last card?", "Yes!", "No");
             var result = await dialog ?? false;
-            await hubConnection.SendAsync("SetLastCardStatus", result);
+            await _hubConnection.SendAsync("SetLastCardStatus", result);
         });
 
-        hubConnection.On<UIChat>("ReceiveChat", message =>
+        _hubConnection.On<UIChat>("ReceiveChat", message =>
         {
-            room.Chats.Add(message);
+            _room.Chats.Add(message);
             var sender = message.Sender.Email;
-            if(sender != username) Snackbar.Add($"New message from {sender}.", Severity.Info);
+            if(sender != _username) Snackbar.Add($"New message from {sender}.", Severity.Info);
             StateHasChanged();
         });
 
-        hubConnection.On<SystemMessage>("ReceiveSystemMessage", message =>
+        _hubConnection.On<SystemMessage>("ReceiveSystemMessage", message =>
         {
             var severity = message.Type switch
             {
@@ -211,100 +217,100 @@ else
             Snackbar.Add(message.Text, severity);
         });
 
-        hubConnection.On("ReclaimPile", () =>
+        _hubConnection.On("ReclaimPile", () =>
         {
             var cards = Game.Pile.Reclaim();
             Game.DeckCount += cards.Count;
             StateHasChanged();
         });
 
-        hubConnection.On<int>("RemoveCardsFromDeck", num =>
+        _hubConnection.On<int>("RemoveCardsFromDeck", num =>
         {
             Game.DeckCount -= num;
             StateHasChanged();
         });
 
-        hubConnection.On<UIHand, int>("RemoveCardsFromPlayerHand", (hand, num) =>
+        _hubConnection.On<UIHand, int>("RemoveCardsFromPlayerHand", (hand, num) =>
         {
-            var playerHand = Game.Hands.Single(h => h.User.Email == hand.User.Email);
+            var playerHand = Game.Hands.Single(h => h.User!.Email == hand.User!.Email);
             for (int i = 0; i < num; i++) playerHand.Cards.RemoveAt(0);
             StateHasChanged();
         });
 
-        hubConnection.On<List<Card>>("RemoveCardRangeFromHand", cards =>
+        _hubConnection.On<List<Card>>("RemoveCardRangeFromHand", cards =>
         {
-            Hand.Cards.RemoveAll(c => cards.Contains(c));
+            Hand.Cards.RemoveAll(cards.Contains);
             StateHasChanged();
         });
 
-        hubConnection.On("RemoveFromRoom", () =>
+        _hubConnection.On("RemoveFromRoom", () =>
         {
-            room = null;
+            _room = null;
             StateHasChanged();
         });
 
-        hubConnection.On<UIHand>("RemoveHandFromRoom", hand =>
+        _hubConnection.On<UIHand>("RemoveHandFromRoom", hand =>
         {
-            _ = Game.Hands.RemoveAll(h => h.User.Email == hand.User.Email);
-            Snackbar.Add($"{hand.User.Email} has left the room.", Severity.Info);
+            _ = Game.Hands.RemoveAll(h => h.User!.Email == hand.User!.Email);
+            Snackbar.Add($"{hand.User!.Email} has left the room.", Severity.Info);
             StateHasChanged();
         });
 
-        hubConnection.On<Card>("SetCurrentRequest", request =>
+        _hubConnection.On<Card>("SetCurrentRequest", request =>
         {
             Game.CurrentRequest = request;
             StateHasChanged();
         });
 
-        hubConnection.On<int>("UpdateTurn", turn =>
+        _hubConnection.On<int>("UpdateTurn", turn =>
         {
             Game.CurrentTurn = turn;
-            var current = Game.Hands[turn].User.Email;
-            var turnText = current == username ? "your" : $"{current}'s";
+            var current = Game.Hands[turn].User!.Email;
+            var turnText = current == _username ? "your" : $"{current}'s";
             var message = $"It is now {turnText} turn.";
             Snackbar.Add(message, Severity.Info);
             StateHasChanged();
         });
 
-        hubConnection.On<bool>("UpdateGameStatus", started =>
+        _hubConnection.On<bool>("UpdateGameStatus", started =>
         {
             Game.IsStarted = started;
             if (started) Snackbar.Add($"The game has started", Severity.Info);
             StateHasChanged();
         });
 
-        await hubConnection.StartAsync();
+        await _hubConnection.StartAsync();
     }
 
     async Task Send(string message) =>
-    await hubConnection.SendAsync("SendChat", room.InviteLink, message);
+    await _hubConnection.SendAsync("SendChat", _room.InviteLink, message);
 
-    async Task CreateRoom(string password) => await hubConnection.SendAsync("CreateRoom", password);
+    async Task CreateRoom(string password) => await _hubConnection.SendAsync("CreateRoom", password);
 
     async Task JoinRoom((string InviteLink, string Password) room) =>
-    await hubConnection.SendAsync("JoinRoom", room.InviteLink, room.Password);
+    await _hubConnection.SendAsync("JoinRoom", room.InviteLink, room.Password);
 
-    async Task LeaveRoom(bool isEnding = false) => await hubConnection.SendAsync("LeaveRoom", room.InviteLink, isEnding);
+    async Task LeaveRoom(bool isEnding = false) => await _hubConnection.SendAsync("LeaveRoom", _room.InviteLink, isEnding);
 
-    async Task StartGame() => await hubConnection.SendAsync("StartGame", room.InviteLink);
+    async Task StartGame() => await _hubConnection.SendAsync("StartGame", _room.InviteLink);
 
     private void AddCardToTurn(Card card)
     {
-        currentTurn.Add(card);
+        _currentTurn.Add(card);
         StateHasChanged();
     }
 
     private void RemoveCardFromTurn(Card card)
     {
-        currentTurn.Remove(card);
+        _currentTurn.Remove(card);
         StateHasChanged();
     }
 
     async Task PerformTurn(List<Card> cards)
     {
-        await hubConnection.SendAsync("PerformTurn", room.InviteLink, cards);
+        await _hubConnection.SendAsync("PerformTurn", _room.InviteLink, cards);
         StateHasChanged();
     }
 
-    public async ValueTask DisposeAsync() => await hubConnection.DisposeAsync();
+    public async ValueTask DisposeAsync() => await _hubConnection.DisposeAsync();
 }

--- a/src/Karata.Web/Pages/Play.razor
+++ b/src/Karata.Web/Pages/Play.razor
@@ -128,18 +128,6 @@ else
         })
         .Build();
 
-        hubConnection.On<int>("AddCardsToDeck", num =>
-        {
-            Game.DeckCount += num;
-            StateHasChanged();
-        });
-
-        hubConnection.On<Card>("AddCardToPile", card =>
-        {
-            Game.Pile.Push(card);
-            StateHasChanged();
-        });
-
         hubConnection.On<UIHand, int>("AddCardsToPlayerHand", (hand, num) =>
         {
             var playerHand = Game.Hands.Single(h => h.User.Email == hand.User.Email);
@@ -225,7 +213,8 @@ else
 
         hubConnection.On("ReclaimPile", () =>
         {
-            _ = Game.Pile.Reclaim();
+            var cards = Game.Pile.Reclaim();
+            Game.DeckCount += cards.Count;
             StateHasChanged();
         });
 

--- a/src/Karata.Web/Program.cs
+++ b/src/Karata.Web/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddSignalR().AddHubOptions<GameHub>(options =>
 builder.Services.AddSingleton<IUserIdProvider, EmailBasedUserIdProvider>();
 builder.Services.AddSingleton<IPasswordService, PasswordService>();
 builder.Services.AddSingleton<IEngine, KarataEngine>();
+builder.Services.AddSingleton<PresenceService>();
 builder.Services.AddScoped<IClipboardService, ClipboardService>();
 builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<User>>();
 builder.Services.AddScoped<CookieService>();

--- a/src/Karata.Web/Services/PresenceService.cs
+++ b/src/Karata.Web/Services/PresenceService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Text.Json;
 
 namespace Karata.Web.Services;
 
@@ -14,7 +13,6 @@ public class PresenceService
             set.Add(room);
             return set;
         });
-        Debug();
     }
     
     public void RemovePresence(string user, string room)
@@ -24,7 +22,6 @@ public class PresenceService
             set.Remove(room);
             return set;
         });
-        Debug();
     }
     
     public bool TryGetPresence(string user, out HashSet<string> rooms)
@@ -37,6 +34,4 @@ public class PresenceService
         get => _presence[key];
         set => _presence[key] = value;
     }
-
-    private void Debug() => Console.WriteLine(JsonSerializer.Serialize(_presence));
 }

--- a/src/Karata.Web/Services/PresenceService.cs
+++ b/src/Karata.Web/Services/PresenceService.cs
@@ -1,0 +1,42 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Karata.Web.Services;
+
+public class PresenceService
+{
+    private readonly ConcurrentDictionary<string, HashSet<string>> _presence = new();
+    
+    public void AddPresence(string user, string room)
+    {
+        _presence.AddOrUpdate(user, new HashSet<string> { room }, (_, set) =>
+        {
+            set.Add(room);
+            return set;
+        });
+        Debug();
+    }
+    
+    public void RemovePresence(string user, string room)
+    {
+        _presence.AddOrUpdate(user, new HashSet<string> { room }, (_, set) =>
+        {
+            set.Remove(room);
+            return set;
+        });
+        Debug();
+    }
+    
+    public bool TryGetPresence(string user, out HashSet<string> rooms)
+    {
+        return _presence.TryGetValue(user, out rooms);
+    }
+
+    public HashSet<string> this[string key]
+    {
+        get => _presence[key];
+        set => _presence[key] = value;
+    }
+
+    private void Debug() => Console.WriteLine(JsonSerializer.Serialize(_presence));
+}

--- a/src/Karata.Web/Shared/Game/JoinUI.razor
+++ b/src/Karata.Web/Shared/Game/JoinUI.razor
@@ -54,7 +54,6 @@
         if (string.IsNullOrWhiteSpace(inviteLink))
         {
             joining = false;
-            // TODO: Decouple
             Snackbar.Add("Invite link cannot be empty.", Severity.Error);
             return;
         }


### PR DESCRIPTION
This PR introduces enhancements to how connections between the SignalR hub on the server and the client are handled.

> **Warning**
> This PR contains awesomeness.

## Remove all players from game on end

Fixes #19 

A new SignalR client method, `EndGame` has been introduced, that is called on all clients on a room when the game ends, and lets the client figure out how to gracefully end the game. Currently, it's doing this by calling LeaveRoom with a new parameter, `isEnding`, which allows the client to bypass some checks in the hub.

## End game and remove all users when one user disconnects

Fixes #20 

For this, I've added a new singleton service, PresenceService, which tracks games a user is currently part of. The implementation of PresenceService is a ConcurrentDictionary - the same implementation used by Microsoft.Extensions.Caching.Memory. If a user disconnects before the game ends, a lookup in the ConcurrentDictionary allows the GameHub to find and end all games a user is part of - by calling `EndGame` on each of the rooms.

## Add reason for game ending

Fixes #30 

A new string parameter `reason` has been added to `EndGame`, that lets the hub provide the client with the reason the game ended. The client is currently using this parameter in the game over message, like so:

```csharp
$"Game Over! {reason}"
```

> **Note**
> I have not removed the `winner` parameter from `EndGame` as it may prove useful in implementing #29.
