### PR TITLE
Specific Error Messages for Turn Validation Failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is also a custom cards library [here](https://github.com/sixpeteunder/kara
 - [ ] Configurable "fines" (off by default) - Trivial.
 - [ ] Player disconnection/reconnection handling - being tracked in [#8](https://github.com/sixpeteunder/karata/issues/8).
 - [ ] Resumable games - blocked by connection handling.
-- [ ] Configurable rules - technically already possible via [IEngine](https://github.com/sixpeteunder/karata/blob/main/src/Karata.Web/Engines/IEngine.cs).
+- [ ] Configurable rules.
 - [ ] Game replays - no progress.
 - [ ] Friend system - no progress.
 - [ ] Tournaments/Knockouts - no progress.

--- a/src/Karata.Client/Extensions/CardExtensions.cs
+++ b/src/Karata.Client/Extensions/CardExtensions.cs
@@ -1,0 +1,16 @@
+using Karata.Cards;
+using static Karata.Cards.Card.CardFace;
+
+namespace Karata.Client.Extensions;
+
+public static class CardExtensions
+{
+    public static string GetImageSrc(this Card card, bool faceUp = true)
+    {
+        if (!faceUp) return "img/cards/Back.svg";
+        
+        return card is { Face: Joker }
+            ? $"img/cards/{card.Suit.ToString()}.svg"
+            : $"img/cards/{card.Face.ToString()}{card.Suit.ToString()}.svg";
+    }
+}

--- a/src/Karata.Client/Pages/Rules.razor
+++ b/src/Karata.Client/Pages/Rules.razor
@@ -1,0 +1,6 @@
+@page "/Rules"
+<h3>Rules</h3>
+
+@code {
+    
+}

--- a/src/Karata.Client/Shared/Game/CardComponent.razor
+++ b/src/Karata.Client/Shared/Game/CardComponent.razor
@@ -1,4 +1,4 @@
-<img class="card cursor-pointer" src="@( FaceUp ? ImageSrc : "img/cards/Back.svg" )" @onclick="Click" alt="@Card.GetName()"/>
+<img class="card cursor-pointer" src="@Card.GetImageSrc(faceUp: FaceUp)" @onclick="Click" alt="@Card.GetName()"/>
 
 @code {
     [Parameter]
@@ -11,8 +11,4 @@
     public EventCallback<Card> OnClick { get; set; }
 
     private async Task Click() => await OnClick.InvokeAsync(Card);
-
-    private string ImageSrc => Card is { Face: Joker} 
-        ? $"img/cards/{Card.Suit.ToString()}.svg"
-        : $"img/cards/{Card.Face.ToString()}{Card.Suit.ToString()}.svg";
 }

--- a/src/Karata.Client/_Imports.razor
+++ b/src/Karata.Client/_Imports.razor
@@ -12,6 +12,7 @@
 @using Karata.Client.Shared
 @using Karata.Cards
 @using Karata.Cards.Extensions
+@using Karata.Client.Extensions
 @using Karata.Shared.Models
 @using Karata.Client.Shared.Game
 @using MudBlazor

--- a/src/Karata.Server/Engine/Exceptions/CardRequestedException.cs
+++ b/src/Karata.Server/Engine/Exceptions/CardRequestedException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class CardRequestedException : TurnValidationException
+{
+    public override string Message =>
+        "A card has been requested. Your turn must either start with the requested card or block the request.";
+}

--- a/src/Karata.Server/Engine/Exceptions/DrawCardsException.cs
+++ b/src/Karata.Server/Engine/Exceptions/DrawCardsException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class DrawCardsException : TurnValidationException
+{
+    public override string Message =>
+        "You have pending cards to draw. You must either draw these cards, add to them or block them.";
+}

--- a/src/Karata.Server/Engine/Exceptions/InvalidAnswerException.cs
+++ b/src/Karata.Server/Engine/Exceptions/InvalidAnswerException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class InvalidAnswerException : TurnValidationException
+{
+    public override string Message =>
+        "Invalid answer card. An answer is only valid if it is the same face or suit as the previous card.";
+}

--- a/src/Karata.Server/Engine/Exceptions/InvalidCardSequenceException.cs
+++ b/src/Karata.Server/Engine/Exceptions/InvalidCardSequenceException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class InvalidCardSequenceException : TurnValidationException
+{
+    public override string Message =>
+        "Invalid card sequence. Subsequent cards must either match the previous card's face or be answers.";
+}

--- a/src/Karata.Server/Engine/Exceptions/InvalidFirstCardException.cs
+++ b/src/Karata.Server/Engine/Exceptions/InvalidFirstCardException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class InvalidFirstCardException : TurnValidationException
+{
+    public override string Message =>
+        "Invalid first card. The first card played must match the face or suit of the previous card.";
+}

--- a/src/Karata.Server/Engine/Exceptions/SubsequentAceOrJokerException.cs
+++ b/src/Karata.Server/Engine/Exceptions/SubsequentAceOrJokerException.cs
@@ -1,0 +1,7 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public class SubsequentAceOrJokerException : TurnValidationException
+{
+    public override string Message =>
+        "Invalid card order. An subsequent Ace/Joker can only go on top of a question or another Ace/Joker.";
+}

--- a/src/Karata.Server/Engine/Exceptions/TurnValidationException.cs
+++ b/src/Karata.Server/Engine/Exceptions/TurnValidationException.cs
@@ -1,0 +1,5 @@
+namespace Karata.Server.Engine.Exceptions;
+
+public abstract class TurnValidationException : Exception
+{
+}

--- a/src/Karata.Server/Engine/KarataEngine.cs
+++ b/src/Karata.Server/Engine/KarataEngine.cs
@@ -1,14 +1,29 @@
+using Karata.Server.Engine.Exceptions;
 using static Karata.Cards.Card.CardFace;
 using static Karata.Server.Models.GameRequestLevel;
 
-namespace Karata.Server.Engines;
+namespace Karata.Server.Engine;
 
-// This class should not interact with ApplicationUser or Room at all
-public class KarataEngine : IEngine
+/// <summary>
+/// <see cref="KarataEngine"/> has methods to check that the turn played is valid, and generate a
+/// <see cref="GameDelta"/> for the turn.
+/// </summary>
+/// 
+/// <remarks>
+/// - This class should not interact with <see cref="User"/> or <see cref="Room"/>.
+/// </remarks>
+public static class KarataEngine
 {
-    public bool ValidateTurnCards(Game game, List<Card> turnCards)
+    /// <summary>
+    /// <see cref="EnsureTurnIsValid"/> checks that the turn played is valid.
+    /// </summary>
+    /// 
+    /// <exception cref="TurnValidationException">
+    /// Thrown when the turn is not valid.
+    /// </exception>
+    public static void EnsureTurnIsValid(Game game, List<Card> turnCards)
     {
-        if (turnCards.Count == 0) return true;
+        if (turnCards is { Count: 0 }) return; //An empty turn is always valid.
 
         var topCard = game.Pile.Peek();
         var firstCard = turnCards[0];
@@ -17,8 +32,8 @@ public class KarataEngine : IEngine
         if (game.CurrentRequest is not null && firstCard is not { Face: Ace })
         {
             var request = game.CurrentRequest;
-            if (request is not { Face: None } && !firstCard.FaceEquals(request)) return false;
-            if (!firstCard.SuitEquals(request)) return false;
+            if (request is not { Face: None } && !firstCard.FaceEquals(request)) throw new CardRequestedException();
+            if (!firstCard.SuitEquals(request)) throw new CardRequestedException();
         }
 
         // If the top card is a "bomb", the next card should counter or block it.
@@ -27,11 +42,11 @@ public class KarataEngine : IEngine
             // Joker can only be countered by a joker while 2 and 3 can be countered by 2, 3 and Joker.
             if (topCard is { Face: Joker })
             {
-                if (firstCard is not { Face: Joker }) return false;
+                if (firstCard is not { Face: Joker }) throw new DrawCardsException();
             }
             else
             {
-                if (!firstCard.IsBomb()) return false;
+                if (!firstCard.IsBomb()) throw new DrawCardsException();
             }
         }
         
@@ -42,7 +57,7 @@ public class KarataEngine : IEngine
             var prevCard = sequence[i - 1];
 
             // First card
-            if (i == 1)
+            if (i is 1)
             {
                 // Ace and joker go on top of anything
                 if (thisCard is { Face: Ace or Joker }) continue;
@@ -50,7 +65,9 @@ public class KarataEngine : IEngine
                 // Anything goes on top of an ace or joker
                 if (prevCard is { Face: Ace or Joker }) continue;
                 if (!thisCard.FaceEquals(prevCard) && !thisCard.SuitEquals(prevCard))
-                    return false;
+                {
+                    throw new InvalidFirstCardException();
+                }
             }
             // Subsequent cards
             else
@@ -61,14 +78,18 @@ public class KarataEngine : IEngine
                     {
                         // Ace, when not the first card, can only go on top of a question or another ace.
                         if (!prevCard.IsQuestion() && prevCard is not { Face: Ace })
-                            return false;
+                        {
+                            throw new SubsequentAceOrJokerException();
+                        }
                         break;
                     }
                     case { Face: Joker }:
                     {
                         // Joker, when not the first card, can only go on top of a question or another joker.
                         if (!prevCard.IsQuestion() && prevCard is not { Face: Joker })
-                            return false;
+                        {
+                            throw new SubsequentAceOrJokerException();
+                        }
                         break;
                     }
                     default:
@@ -77,13 +98,14 @@ public class KarataEngine : IEngine
                         if (prevCard.IsQuestion())
                         {
                             if (!thisCard.FaceEquals(prevCard) && !thisCard.SuitEquals(prevCard))
-                                return false;
+                            {
+                                throw new InvalidAnswerException();
+                            }
                         }
                         else
                         {
                             // If the previous card is not a question, the current card must be of the same face.
-                            if (!thisCard.FaceEquals(prevCard))
-                                return false;
+                            if (!thisCard.FaceEquals(prevCard)) throw new InvalidCardSequenceException();
                         }
 
                         break;
@@ -91,11 +113,12 @@ public class KarataEngine : IEngine
                 }
             }
         }
-
-        return true;
     }
 
-    public GameDelta GenerateTurnDelta(Game game, List<Card> turnCards)
+    /// <summary>
+    /// <see cref="GenerateTurnDelta"/> Generates a <see cref="GameDelta"/> for this turn.
+    /// </summary>
+    public static GameDelta GenerateTurnDelta(Game game, List<Card> turnCards)
     {
         var delta = new GameDelta();
 

--- a/src/Karata.Server/Engines/IEngine.cs
+++ b/src/Karata.Server/Engines/IEngine.cs
@@ -1,7 +1,0 @@
-namespace Karata.Server.Engines;
-
-public interface IEngine
-{
-    bool ValidateTurnCards(Game game, List<Card> turnCards);
-    GameDelta GenerateTurnDelta(Game game, List<Card> turnCards);
-}

--- a/src/Karata.Server/Program.cs
+++ b/src/Karata.Server/Program.cs
@@ -1,10 +1,9 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.ResponseCompression;
 using Karata.Server.Data;
+using Karata.Server.Engine;
 using Npgsql;
-using Microsoft.AspNetCore.SignalR;
 using Karata.Server.Services;
-using Karata.Server.Engines;
 using Microsoft.EntityFrameworkCore;
 using Karata.Server.Hubs;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -56,7 +55,6 @@ builder.Services.AddSignalR().AddHubOptions<GameHub>(options =>
 
 // builder.Services.AddSingleton<IUserIdProvider, EmailBasedUserIdProvider>();
 builder.Services.AddSingleton<IPasswordService, PasswordService>();
-builder.Services.AddSingleton<IEngine, KarataEngine>();
 builder.Services.AddSingleton<PresenceService>();
 builder.Services.AddResponseCompression(opts =>
 {

--- a/test/Karata.Server.Tests/Engines/KarataEngineTest.cs
+++ b/test/Karata.Server.Tests/Engines/KarataEngineTest.cs
@@ -1,6 +1,7 @@
 using Karata.Cards;
 using Karata.Cards.Extensions;
-using Karata.Server.Engines;
+using Karata.Server.Engine;
+using Karata.Server.Engine.Exceptions;
 using Karata.Server.Models;
 using static Karata.Cards.Card.CardColor;
 using static Karata.Cards.Card.CardFace;
@@ -33,9 +34,10 @@ public class KarataEngineTest
     public void ValidateTurnCardsTest(int identifier, Game game, List<Card> cards, bool expectedValidity)
 #pragma warning restore xUnit1026
     {
-        var engine = new KarataEngine();
-        var actualValidity = engine.ValidateTurnCards(game, cards);
-        Assert.Equal(expectedValidity, actualValidity);
+        if (!expectedValidity)
+        {
+            Assert.ThrowsAny<TurnValidationException>(() => KarataEngine.EnsureTurnIsValid(game, cards));
+        }
     }
 
     [Theory]
@@ -44,8 +46,7 @@ public class KarataEngineTest
     public void GenerateTurnDeltaTest(int identifier, Game game, List<Card> cards, GameDelta expectedDelta)
 #pragma warning restore xUnit1026
     {
-        var engine = new KarataEngine();
-        var actualDelta = engine.GenerateTurnDelta(game, cards);
+        var actualDelta = KarataEngine.GenerateTurnDelta(game, cards);
         Assert.Equal(expectedDelta, actualDelta);
     }
 


### PR DESCRIPTION
Resolves #43.

Switches from displaying a generic "That card sequence is invalid." message, to more specific error messages for each class of turn validation failures.

In addition, removed the unnecessarily complex structure around calling methods on `KarataEngine`:

#### Before

- Create instance of class `KarataEngine`.
- Add created instance to DI as a concrete implementation of interface `IEngine`.
- Inject an instance - `_engine` - of interface `IEngine` into wherever it's needed.
- Call instance methods `_engine.ValidateTurnCards`, `_engine.GenerateTurnDelta` on `IEngine`.

#### After

 - Call static methods `KarataEngine.ValidateTurnCards`, `KarataEngine.GenerateTurnDelta` on `KarataEngine`.

